### PR TITLE
Improved deployment of dudle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@
 # run:
 # docker run -it -p 8888:80 -v /srv/dudle-backup:/backup:Z  --rm --name my-running-dudle my-dudle
 
-FROM centos:6
+FROM centos:7
 
 RUN yum -y install httpd ruby ruby-devel git rubygems gcc make epel-release wget
-RUN yum -y install ruby-gettext-package
+RUN gem install gettext iconv
 RUN yum clean all
 
 CMD [ "/usr/local/bin/start.sh" ]
@@ -22,7 +22,7 @@ COPY ./cgi/ /var/www/html/cgi-bin/
 
 RUN sed -i \
         -e 's/^<Directory "\/var\/www\/html">/<Directory "\/var\/www\/html-original">/g' \
-        -e 's/^ScriptAlias \/cgi-bin\//#ScriptAlias \/cgi-bin\//g' \
+        -e 's/^ *ScriptAlias \/cgi-bin\//#ScriptAlias \/cgi-bin\//g' \
         /etc/httpd/conf/httpd.conf \
     && sed -ri \
 		's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@
 #
 # run:
 # docker run -it -p 8888:80 -v /srv/dudle-backup:/backup:Z  --rm --name my-running-dudle my-dudle
-
+#
+# build partly based on https://github.com/fonk/docker-dudle/blob/master/Dockerfile
 FROM fedora:24
-
 RUN dnf -y install httpd ruby ruby-devel git bison flex glib2 glib2-devel rubygems gcc make wget gettext gettext-devel
-RUN dnf -y install tar which 
+RUN dnf -y install tar which glibc-all-langpacks glibc-langpack-en rubygem-i18n
 RUN dnf clean all
-RUN gem install fast_gettext gettext locale 
-
+RUN gem install fast_gettext gettext locale
+RUN export RUBYOPT="-KU -E utf-8:utf-8"
 RUN wget marcin.owsiany.pl/potool/potool-0.16.tar.gz
 RUN tar -xvf potool-0.16.tar.gz
 WORKDIR potool-0.16
@@ -21,11 +21,12 @@ RUN make -f Makefile
 RUN make install
 WORKDIR /
 
-# This part does not work, had to build seperately and then copy into the container
-#RUN git clone https://github.com/bkmgit/dudle.git cgi 
-#WORKDIR cgi 
-#RUN make -f Makefile
-#WORKDIR /
+RUN git clone https://github.com/bkmgit/dudle.git cgi 
+WORKDIR cgi 
+# Need to build with localization support
+RUN LC_ALL=en_US.utf8 make 
+
+WORKDIR /
 
 CMD [ "/usr/local/bin/start.sh" ]
 
@@ -50,4 +51,3 @@ COPY ./skin/conf/ /var/www/html/cgi-bin/
 RUN chmod -R go-w /var/www/html/cgi-bin
 RUN chgrp apache /var/www/html/cgi-bin
 RUN chmod 775 /var/www/html/cgi-bin
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 # preparations:
+# git clone https://github.com/bkmgit/dudle-docker/
+# cd dudle-docker
 # git clone https://github.com/bkmgit/dudle.git cgi
 #
 # build:
 # docker build -t my-dudle .
 #
+# backup directory
+# mkdir -p /srv/dudle/backup
+#
 # run:
-# docker run -it -p 8888:80 -v /srv/dudle-backup:/backup:Z  --rm --name my-running-dudle my-dudle
+# scripts/maintenance/dudle-maint.sh run
 #
 # build partly based on https://github.com/fonk/docker-dudle/blob/master/Dockerfile
 FROM fedora:26

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # preparations:
-# git clone https://github.com/kellerben/dudle.git cgi
+# git clone https://github.com/bkmgit/dudle.git cgi
 #
 # build:
 # docker build -t my-dudle .
@@ -37,8 +37,4 @@ RUN chmod -R go-w /var/www/html/cgi-bin
 RUN chgrp apache /var/www/html/cgi-bin
 RUN chmod 775 /var/www/html/cgi-bin
 
-RUN cd /var/www/html/cgi-bin && \
-    for i in locale/?? locale/??_??; do \
-        wget -O $i/dudle.mo https://dudle.inf.tu-dresden.de/locale/`basename $i`/dudle.mo; \
-    done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ WORKDIR /
 RUN git clone https://github.com/bkmgit/dudle.git cgi
 WORKDIR cgi 
 RUN mkdir extensions
-WORKDIR extensions
 RUN git clone https://github.com/kellerben/dudle-extensions-participate.git
+RUN mv participate extensions
 RUN git clone https://github.com/kellerben/dudle-extensions-gpgauth.git
-RUN git clone https://github.com/kellerben/dudle-extensions-anonymous.git
-WORKDIR /
+RUN mv gpgauth extensions
+RUN git clone https://github.com/kellerben/dudle-extensions-anonymous.git anonymous
+RUN mv anonymous extensions
 # Need to build with localization support
 RUN LC_ALL=en_US.utf8 make 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@
 # docker run -it -p 8888:80 -v /srv/dudle-backup:/backup:Z  --rm --name my-running-dudle my-dudle
 #
 # build partly based on https://github.com/fonk/docker-dudle/blob/master/Dockerfile
-FROM fedora:24
+FROM fedora:26
 RUN dnf -y install httpd ruby ruby-devel git bison flex glib2 glib2-devel rubygems gcc make wget gettext gettext-devel
-RUN dnf -y install tar which glibc-all-langpacks glibc-langpack-en rubygem-i18n
+RUN dnf -y install tar which glibc-all-langpacks glibc-langpack-en rubygem-i18n rubygem-json
 RUN dnf clean all
 RUN gem install fast_gettext gettext locale
 RUN export RUBYOPT="-KU -E utf-8:utf-8"
@@ -21,8 +21,13 @@ RUN make -f Makefile
 RUN make install
 WORKDIR /
 
-RUN git clone https://github.com/bkmgit/dudle.git cgi 
+RUN git clone https://github.com/bkmgit/dudle.git cgi
 WORKDIR cgi 
+RUN mkdir extensions
+WORKDIR extensions
+RUN git clone https://github.com/kellerben/dudle-extensions-participate.git
+RUN git clone https://github.com/kellerben/dudle-extensions-gpgauth.git
+RUN git clone https://github.com/kellerben/dudle-extensions-anonymous.git
 # Need to build with localization support
 RUN LC_ALL=en_US.utf8 make 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,25 @@
 # run:
 # docker run -it -p 8888:80 -v /srv/dudle-backup:/backup:Z  --rm --name my-running-dudle my-dudle
 
-FROM centos:7
+FROM fedora:24
 
-RUN yum -y install httpd ruby ruby-devel git rubygems gcc make epel-release wget
-RUN gem install gettext iconv
-RUN yum clean all
+RUN dnf -y install httpd ruby ruby-devel git bison flex glib2 glib2-devel rubygems gcc make wget gettext gettext-devel
+RUN dnf -y install tar which 
+RUN dnf clean all
+RUN gem install fast_gettext gettext locale 
+
+RUN wget marcin.owsiany.pl/potool/potool-0.16.tar.gz
+RUN tar -xvf potool-0.16.tar.gz
+WORKDIR potool-0.16
+RUN make -f Makefile
+RUN make install
+WORKDIR /
+
+# This part does not work, had to build seperately and then copy into the container
+#RUN git clone https://github.com/bkmgit/dudle.git cgi 
+#WORKDIR cgi 
+#RUN make -f Makefile
+#WORKDIR /
 
 CMD [ "/usr/local/bin/start.sh" ]
 
@@ -36,5 +50,4 @@ COPY ./skin/conf/ /var/www/html/cgi-bin/
 RUN chmod -R go-w /var/www/html/cgi-bin
 RUN chgrp apache /var/www/html/cgi-bin
 RUN chmod 775 /var/www/html/cgi-bin
-
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ WORKDIR /
 RUN git clone https://github.com/bkmgit/dudle.git cgi
 WORKDIR cgi 
 RUN mkdir extensions
-RUN git clone https://github.com/kellerben/dudle-extensions-participate.git
+RUN git clone https://github.com/kellerben/dudle-extensions-participate.git participate
 RUN mv participate extensions
-RUN git clone https://github.com/kellerben/dudle-extensions-gpgauth.git
+RUN git clone https://github.com/kellerben/dudle-extensions-gpgauth.git gpgauth
 RUN mv gpgauth extensions
 RUN git clone https://github.com/kellerben/dudle-extensions-anonymous.git anonymous
 RUN mv anonymous extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR extensions
 RUN git clone https://github.com/kellerben/dudle-extensions-participate.git
 RUN git clone https://github.com/kellerben/dudle-extensions-gpgauth.git
 RUN git clone https://github.com/kellerben/dudle-extensions-anonymous.git
+WORKDIR /
 # Need to build with localization support
 RUN LC_ALL=en_US.utf8 make 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Introduction
 
 This package runs [Dudle](https://dudle.inf.tu-dresden.de/) as a [Docker container](https://www.docker.com/).
 
-Dudle stores data together with the code, which is a bit problematic from Docker point of view. This package contains 'scripts/maintenance/dudle-maint.sh' script which can be used to populate and back up polls to/from the container.
+Dudle stores data together with the code, which is a bit problematic from Docker point of view. This package contains 'scripts/maintenance/dudle-maint.sh' script that can be used to populate and back up polls to/from the container.
 
 Installation
 ============
@@ -18,7 +18,7 @@ Fetch Dudle sources, create the Docker image and a folder for backups:
 If you have an existing Dudle installation and and you want to copy polls to the new container:
 
     # cd /your/old/dudle
-    # tar cvfz /srv/dudle/backup/dudle-backup.tar.gz `find . -maxdepth 1 -type d | egrep -v '\./(extensions|locale|\.bzr|css)|^\.$' | xargs`
+    # tar cvfz /srv/dudle/backup/dudle-backup.tar.gz `find . -maxdepth 1 -type d | egrep -v '\./(extensions|locale|\.git|\.bzr|css)|^\.$' | xargs`
 
 If you want to customize your installation, add your CSS and artwork to 'skin/css/' and create/modify 'skin/conf/config.rb'. For more information on customization, see "Pimp your Installation" section in Dudle README.
 
@@ -57,7 +57,7 @@ The following command updates all software:
 
     scripts/maintenance/dudle-maint.sh upgrade
 
-The command creates a new image and container by upgrading the base image (currently Centos 6), Dudle sources and Dudle Docker image scripts. Before upgrade, all polls are backed up automatically.
+The command creates a new image and container by upgrading the base image (currently Centos 7), Dudle sources and Dudle Docker image scripts. Before upgrade, all polls are backed up automatically.
 
 Other commands
 ==============

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 Fetch Dudle sources, create the Docker image and a folder for backups:
 
     # cd dudle-docker
-    # git clone https://github.com/kellerben/dudle.git cgi
+    # git clone https://github.com/bkmgit/dudle.git cgi
     # docker build -t my-dudle .
     # mkdir -p /srv/dudle/backup
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Installation
 ============
 
 Fetch Dudle sources, create the Docker image and a folder for backups:
-
+    
+    # git clone https://github.com/bkmgit/dudle-docker/
     # cd dudle-docker
     # git clone https://github.com/bkmgit/dudle.git cgi
     # docker build -t my-dudle .

--- a/conf/httpd/dudle.conf
+++ b/conf/httpd/dudle.conf
@@ -24,6 +24,11 @@ DocumentRoot "/var/www/html"
 
     SetEnv RUBYLIB /var/www/html/cgi-bin/
 
+    SetEnv GIT_AUTHOR_NAME="http user"
+    SetEnv GIT_AUTHOR_EMAIL=foo@example.org
+    SetEnv GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+    SetEnv GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+
     RedirectMatch ^/$ /cgi-bin/
 
     #

--- a/conf/httpd/dudle.conf
+++ b/conf/httpd/dudle.conf
@@ -23,7 +23,7 @@ DocumentRoot "/var/www/html"
     AllowOverride All
 
     SetEnv RUBYLIB /var/www/html/cgi-bin/
-
+    SetEnv RUBYOPT "-E UTF-8:UTF-8"
     SetEnv GIT_AUTHOR_NAME="http user"
     SetEnv GIT_AUTHOR_EMAIL=foo@example.org
     SetEnv GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"

--- a/scripts/container/backup.sh
+++ b/scripts/container/backup.sh
@@ -20,7 +20,7 @@ fi
 
 cd $DUDLE_DIR
 
-BACKUP_FOLDERS="`find . -maxdepth 1 -type d | egrep -v '\./(extensions|locale|\.bzr|css)|^\.$' | xargs`"
+BACKUP_FOLDERS="`find . -maxdepth 1 -type d | egrep -v '\./(extensions|locale|\.git|css)|^\.$' | xargs`"
 
 echo Backing up folders: $BACKUP_FOLDERS
 

--- a/scripts/container/start.sh
+++ b/scripts/container/start.sh
@@ -12,6 +12,11 @@ fi
 
 touch $INIT_LOCK_FILE
 
+rm -f /var/run/httpd/httpd.pid
+
 httpd -DFOREGROUND
 
 echo httpd exited
+
+# in case of httpd errors, keep container up until maintenance arrives
+sleep infinity

--- a/scripts/container/start.sh
+++ b/scripts/container/start.sh
@@ -2,7 +2,7 @@
 
 . `dirname $0`/dudle-config
 
-INIT_LOCK_FILE=/var/lock/dudle-container-initialized
+INIT_LOCK_FILE=/var/tmp/dudle-container-initialized
 
 if [ ! -e "$INIT_LOCK_FILE" ] && [ -e $BACKUP_FILE ]; then
     echo Restoring data from backup...
@@ -14,3 +14,4 @@ touch $INIT_LOCK_FILE
 
 httpd -DFOREGROUND
 
+echo httpd exited

--- a/scripts/maintenance/dudle-maint.sh
+++ b/scripts/maintenance/dudle-maint.sh
@@ -64,6 +64,10 @@ case "$1" in
         get_existing
         backup
         ;;
+    cleanup)
+        get_existing
+        cleanup
+        ;;
     connect)
         get_existing
         connect

--- a/scripts/maintenance/dudle-maint.sh
+++ b/scripts/maintenance/dudle-maint.sh
@@ -19,6 +19,12 @@ backup() {
     docker exec $CONTAINER_ID /usr/local/bin/backup.sh || exit 1
 }
 
+cleanup() {
+    echo Running cleanup for container $CONTAINER_ID
+    
+    docker exec $CONTAINER_ID bash /cgi/dudle_cleanup.sh || exit 1
+}
+
 connect() {
     echo Connecting to container $CONTAINER_ID
 

--- a/scripts/maintenance/dudle-maint.sh
+++ b/scripts/maintenance/dudle-maint.sh
@@ -94,6 +94,6 @@ case "$1" in
         docker logs $CONTAINER_ID
         ;;
     *)
-        echo "Usage: $0 {run|backup|connect|start|stop|restart|upgrade|logs}"
+        echo "Usage: $0 {run|backup|cleanup|connect|start|stop|restart|upgrade|logs}"
 esac
 


### PR DESCRIPTION
Should be able to clone dudle into container and build directly. At present points to slightly updated dudle repository with further language added, but should also work with original dudle repository as of 10 September 2016. May be able to clean up further and minimize size of image. Should also work with hopefully minor modifications on Cento OS 7 container.
